### PR TITLE
Function climate heating state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,5 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 
 ### Community attribution up for approval:
-- Climate entity: Added "HVAC.Heating", animating the Climate controller to display the temperature arc with a red hue with the status "heating".
-
-
+- Added "hvac_action", (Heating / Fan / Off) based on TRIAC register (heating element)
+    

--- a/custom_components/systemair_modbus/climate.py
+++ b/custom_components/systemair_modbus/climate.py
@@ -54,7 +54,7 @@ class SystemairVTRClimate(SystemairBaseEntity, ClimateEntity):
         self._attr_target_temperature_step = 0.5
 
         self._attr_preset_modes = list(PRESET_TO_COMMAND_MODE.keys())
-        self._attr_hvac_modes = [HVACMode.AUTO, HVACMode.FAN_ONLY, HVACMode.HEAT]
+        self._attr_hvac_modes = [HVACMode.AUTO, HVACMode.FAN_ONLY]
         if self._stop_allowed():
             self._attr_hvac_modes.append(HVACMode.OFF)
 
@@ -99,11 +99,6 @@ class SystemairVTRClimate(SystemairBaseEntity, ClimateEntity):
         if man == 0 and self._stop_allowed():
             return HVACMode.OFF
 
-        # If triac is active, show as HEAT mode in the UI
-        triac_val = self._get_int("triac_after_manual_override", 0)
-        if triac_val > 0:
-            return HVACMode.HEAT
-
         mode = self._get_int("mode_status_register", 0)
         if mode == 0:
             return HVACMode.AUTO
@@ -114,7 +109,7 @@ class SystemairVTRClimate(SystemairBaseEntity, ClimateEntity):
             if not self._stop_allowed():
                 return
             await self._client.write_register(self._model.ADDR_MANUAL_SPEED_COMMAND, 0)
-        elif hvac_mode in [HVACMode.AUTO, HVACMode.HEAT]:
+        elif hvac_mode == HVACMode.AUTO:
             await self._client.write_register(self._model.ADDR_MODE_COMMAND, PRESET_TO_COMMAND_MODE["Auto"])
         elif hvac_mode == HVACMode.FAN_ONLY:
             # Keep current mode, but ensure manual speed not 0


### PR DESCRIPTION
Added HVAC Fan state of "heating" in climate.py, which uses the state of the TRIAC heating element.
The arc of the climate entity will now get a red hue and display the state of heating while the heating element is active.

<img width="1176" height="1198" alt="image" src="https://github.com/user-attachments/assets/6d35c1b8-8f9f-4d87-bade-2bd85c966cbf" />
<img width="1176" height="1198" alt="image" src="https://github.com/user-attachments/assets/36a4d963-a265-4ff0-a042-ae653db51906" />
