### PR TITLE
Legg til vifte-entity for CD4 manuell hastighetsstyring

### DIFF
--- a/custom_components/systemair_modbus/__init__.py
+++ b/custom_components/systemair_modbus/__init__.py
@@ -24,8 +24,8 @@ from .coordinator import SystemairCoordinator
 from .modbus import ModbusTcpClient
 from .models import MODEL_REGISTRY
 
-# CD4: kun sensorer (tryggest)
-PLATFORMS_LEGACY_CD4 = ["sensor", "select"]
+# CD4: keep the legacy surface small, but expose manual speed as a fan control.
+PLATFORMS_LEGACY_CD4 = ["sensor", "select", "fan"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/systemair_modbus/fan.py
+++ b/custom_components/systemair_modbus/fan.py
@@ -30,11 +30,7 @@ class SystemairManualSpeedFan(SystemairBaseEntity, FanEntity):
 
     _attr_icon = "mdi:fan"
     _attr_name = None
-    _attr_supported_features = (
-        FanEntityFeature.SET_SPEED
-        | FanEntityFeature.TURN_ON
-        | FanEntityFeature.TURN_OFF
-    )
+    _attr_supported_features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON
 
     def __init__(self, entry: ConfigEntry, coordinator, client, model) -> None:
         super().__init__(entry, coordinator)
@@ -54,6 +50,20 @@ class SystemairManualSpeedFan(SystemairBaseEntity, FanEntity):
             return inverse.get(value)
 
         return {val: key for key, val in self._model.MANUAL_SPEED_OPTIONS.items()}.get(value)
+
+    def _stop_allowed(self) -> bool:
+        raw = self.coordinator.data.get("fan_manual_stop_allowed_register")
+        try:
+            return int(float(raw or 0)) == 1
+        except (TypeError, ValueError):
+            return False
+
+    @property
+    def supported_features(self) -> FanEntityFeature:
+        features = self._attr_supported_features
+        if self._stop_allowed():
+            features |= FanEntityFeature.TURN_OFF
+        return features
 
     @property
     def is_on(self) -> bool | None:
@@ -89,7 +99,7 @@ class SystemairManualSpeedFan(SystemairBaseEntity, FanEntity):
         await self._write_speed("Normal")
 
     async def async_turn_off(self, **kwargs) -> None:
-        if "Stop" in self._model.MANUAL_SPEED_OPTIONS:
+        if self._stop_allowed() and "Stop" in self._model.MANUAL_SPEED_OPTIONS:
             await self._write_speed("Stop")
             return
 

--- a/custom_components/systemair_modbus/fan.py
+++ b/custom_components/systemair_modbus/fan.py
@@ -1,0 +1,111 @@
+"""Fan platform for Systemair Modbus."""
+from __future__ import annotations
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.util.percentage import (
+    ordered_list_item_to_percentage,
+    percentage_to_ordered_list_item,
+)
+
+from .const import DOMAIN
+from .entity import SystemairBaseEntity
+
+ORDERED_MANUAL_SPEEDS = ["Low", "Normal", "High"]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data["coordinator"]
+    client = data["client"]
+    model = coordinator.model
+
+    if hasattr(model, "MANUAL_SPEED_OPTIONS") and hasattr(model, "ADDR_MANUAL_SPEED_COMMAND"):
+        async_add_entities([SystemairManualSpeedFan(entry, coordinator, client, model)])
+
+
+class SystemairManualSpeedFan(SystemairBaseEntity, FanEntity):
+    """Fan entity backed by the unit's manual speed command register."""
+
+    _attr_icon = "mdi:fan"
+    _attr_name = None
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED
+        | FanEntityFeature.TURN_ON
+        | FanEntityFeature.TURN_OFF
+    )
+
+    def __init__(self, entry: ConfigEntry, coordinator, client, model) -> None:
+        super().__init__(entry, coordinator)
+        self._client = client
+        self._model = model
+        self._attr_unique_id = f"{entry.entry_id}_manual_speed_fan"
+
+    def _current_speed(self) -> str | None:
+        raw = self.coordinator.data.get("manual_mode_command_register")
+        try:
+            value = int(float(raw))
+        except (TypeError, ValueError):
+            return None
+
+        inverse = getattr(self._model, "MANUAL_SPEED_OPTIONS_INV", None)
+        if isinstance(inverse, dict):
+            return inverse.get(value)
+
+        return {val: key for key, val in self._model.MANUAL_SPEED_OPTIONS.items()}.get(value)
+
+    @property
+    def is_on(self) -> bool | None:
+        speed = self._current_speed()
+        if speed is None:
+            return None
+        return speed != "Stop"
+
+    @property
+    def percentage(self) -> int | None:
+        speed = self._current_speed()
+        if speed is None:
+            return None
+        if speed == "Stop":
+            return 0
+        if speed not in ORDERED_MANUAL_SPEEDS:
+            return None
+        return ordered_list_item_to_percentage(ORDERED_MANUAL_SPEEDS, speed)
+
+    @property
+    def speed_count(self) -> int:
+        return len(ORDERED_MANUAL_SPEEDS)
+
+    async def async_turn_on(self, percentage: int | None = None, **kwargs) -> None:
+        if percentage is not None:
+            await self.async_set_percentage(percentage)
+            return
+
+        speed = self._current_speed()
+        if speed and speed != "Stop":
+            return
+
+        await self._write_speed("Normal")
+
+    async def async_turn_off(self, **kwargs) -> None:
+        if "Stop" in self._model.MANUAL_SPEED_OPTIONS:
+            await self._write_speed("Stop")
+            return
+
+        await self._write_speed(ORDERED_MANUAL_SPEEDS[0])
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        if percentage <= 0:
+            await self.async_turn_off()
+            return
+
+        speed = percentage_to_ordered_list_item(ORDERED_MANUAL_SPEEDS, percentage)
+        await self._write_speed(speed)
+
+    async def _write_speed(self, speed: str) -> None:
+        await self._client.write_register(
+            self._model.ADDR_MANUAL_SPEED_COMMAND,
+            self._model.MANUAL_SPEED_OPTIONS[speed],
+        )
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
Denne PR-en legger til en egen `fan`-entity for CD4-baserte Systemair/Villavent-aggregater, slik at manuell viftehastighet kan styres med Home Assistant sin standard viftevisning.

Endringen mapper CD4 sine manuelle hastigheter til fan-prosent:
- `Low` -> 33%
- `Normal` -> 67%
- `High` -> 100%
- `Stop` -> 0%, kun hvis aggregatet rapporterer at stopp er støttet

For CD4-enheter som ikke støtter stopp, annonseres ikke `TURN_OFF`. Dersom Home Assistant likevel sender `turn_off` eller `0%`, faller integrasjonen tilbake til `Low` i stedet for å skrive en stop-kommando som aggregatet ignorerer.

Dette er avgrenset til viftefunksjonalitet. Eksisterende `select` for manuell viftehastighet beholdes.

UI-endringer:
<img width="287" height="231" alt="Skjermbilde 2026-06-21 kl  16 56 20" src="https://github.com/user-attachments/assets/61880d42-2754-4f84-90d5-f4b64cbf2c4e" />
<img width="596" height="566" alt="Skjermbilde 2026-06-21 kl  16 56 29" src="https://github.com/user-attachments/assets/09de410b-5338-446d-b7d6-b0f424fc11fe" />


Testet med:
- `python3 -m py_compile custom_components/systemair_modbus/__init__.py custom_components/systemair_modbus/fan.py`
- Praktisk test mot CD4-instans i Home Assistant, der `Low`, `Normal` og `High` fungerer via ny `fan`-entity.