### PR TITLE
Prepare v1.3.0-beta.3 – SAVE improvements and CD4 climate update

### DIFF
--- a/custom_components/systemair_modbus/binary_sensor.py
+++ b/custom_components/systemair_modbus/binary_sensor.py
@@ -102,9 +102,44 @@ async def async_setup_entry(
                 "mdi:air-filter",
             ),
             FreeCoolingActive(entry, coordinator),
+            BoolFromRegister(
+                entry,
+                coordinator,
+                "free_cooling_function_active",
+                "free_cooling_function_active",
+                "mdi:snowflake-check",
+                entity_category=EntityCategory.DIAGNOSTIC,
+                enabled_default=False,
+            ),
+            BoolFromRegister(
+                entry,
+                coordinator,
+                "free_cooling_reliable_temperatures",
+                "free_cooling_reliable_temperatures",
+                "mdi:thermometer-check",
+                entity_category=EntityCategory.DIAGNOSTIC,
+                enabled_default=False,
+            ),
             CookerHoodActive(entry, coordinator),
             EcoFunctionActive(entry, coordinator),
+            EcoModeActive(entry, coordinator),
             PressureGuardActive(entry, coordinator),
+            BoolFromRegister(
+                entry,
+                coordinator,
+                "demand_control_enabled",
+                "demand_control_enabled",
+                "mdi:home-automation",
+                entity_category=EntityCategory.DIAGNOSTIC,
+                enabled_default=False,
+            ),
+            BoolFromRegister(
+                entry,
+                coordinator,
+                "heating_active",
+                "heating_active",
+                "mdi:radiator",
+            ),
         ]
     )
 
@@ -226,10 +261,32 @@ class EcoFunctionActive(SystemairBaseEntity, BinarySensorEntity):
         self._attr_unique_id = f"{entry.entry_id}_eco_function_active_bin"
         self._attr_translation_key = "eco_function_active"
         self._attr_icon = "mdi:leaf"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_entity_registry_enabled_default = False
 
     @property
     def is_on(self) -> bool | None:
         raw = self.coordinator.data.get("eco_function_active")
+        if raw is None:
+            return None
+        try:
+            return int(float(raw)) > 0
+        except (TypeError, ValueError):
+            return None
+
+
+class EcoModeActive(SystemairBaseEntity, BinarySensorEntity):
+    """ECO mode active flag from REG_ECO_MODE_ACTIVE (0/1)."""
+
+    def __init__(self, entry: ConfigEntry, coordinator) -> None:
+        super().__init__(entry, coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_eco_mode_active_bin"
+        self._attr_translation_key = "eco_mode_active"
+        self._attr_icon = "mdi:leaf-circle"
+
+    @property
+    def is_on(self) -> bool | None:
+        raw = self.coordinator.data.get("eco_mode_active")
         if raw is None:
             return None
         try:

--- a/custom_components/systemair_modbus/climate.py
+++ b/custom_components/systemair_modbus/climate.py
@@ -41,9 +41,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 class SystemairCd4Climate(SystemairBaseEntity, ClimateEntity):
     """CD4 supply-air temperature control.
 
-    Systemair documents five discrete supply-air temperature levels.
-    The actual level temperatures are read from the controller, so the same
-    entity works for units with an active re-heater and units without one.
+    CD4 temperature model:
+      - REG_HC_TEMP_LVL (PDF 207 / offset 206) is the R/W level command.
+      - Level 0 is manual summer mode.
+      - Levels 1..11 represent 12..22 °C in 1 °C steps.
+      - REG_HC_TEMP_SP (PDF 208 / offset 207) is read back as the actual
+        temperature setpoint in °C by the CD4 model.
     """
 
     _attr_translation_key = "cd4_climate"
@@ -52,7 +55,16 @@ class SystemairCd4Climate(SystemairBaseEntity, ClimateEntity):
         ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
     )
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_hvac_modes = [HVACMode.FAN_ONLY]
+    # CD4 REG_HC_TEMP_LVL = 0 is the physical panel's temperature OFF /
+    # Systemair "Manual summer mode". This is NOT the same as stopping the
+    # ventilation fans. Fan stop remains separately capability-gated by
+    # REG_FAN_ALLOW_MANUAL_FAN_STOP.
+    _attr_hvac_modes = [HVACMode.FAN_ONLY, HVACMode.OFF]
+
+    # Verified against the CD4 simulator and real VSR500/CD4 register mapping.
+    _attr_min_temp = 12.0
+    _attr_max_temp = 22.0
+    _attr_target_temperature_step = 1.0
 
     def __init__(self, entry: ConfigEntry, coordinator, client, model) -> None:
         super().__init__(entry, coordinator)
@@ -60,13 +72,16 @@ class SystemairCd4Climate(SystemairBaseEntity, ClimateEntity):
         self._model = model
         self._attr_unique_id = f"{entry.entry_id}_cd4_climate"
 
-        # Only expose "Off" when the CD4 controller explicitly allows
-        # manual fan stop.
+        # Keep the last valid target available while REG_HC_TEMP_LVL is 0
+        # (Manual summer / temperature regulation off), so Home Assistant can
+        # return directly to a valid 12..22 °C setpoint.
+        self._last_target_temperature = 20.0
+
+        # Fan-mode OFF is separate from temperature OFF and is only exposed
+        # when the controller explicitly allows manual fan stop.
         self._attr_fan_modes = ["low", "medium", "high"]
         if self._stop_allowed():
             self._attr_fan_modes.append("off")
-
-        self._update_temperature_limits()
 
     def _get_float(self, key: str) -> float | None:
         raw = self.coordinator.data.get(key)
@@ -93,54 +108,56 @@ class SystemairCd4Climate(SystemairBaseEntity, ClimateEntity):
         except (TypeError, ValueError):
             return False
 
-    def _temperature_levels(self) -> dict[int, float]:
-        levels: dict[int, float] = {}
-        for level in range(1, 6):
-            value = self._get_float(f"temperature_level_{level}")
-            if value is not None:
-                levels[level] = value
-        return levels
-
-    def _update_temperature_limits(self) -> None:
-        levels = self._temperature_levels()
-        if not levels:
-            # Documented re-heater defaults; only used before first valid poll.
-            self._attr_min_temp = 12.0
-            self._attr_max_temp = 22.0
-            self._attr_target_temperature_step = 2.5
-            return
-
-        ordered = [levels[level] for level in sorted(levels)]
-        self._attr_min_temp = min(ordered)
-        self._attr_max_temp = max(ordered)
-
-        diffs = [
-            round(ordered[i + 1] - ordered[i], 3)
-            for i in range(len(ordered) - 1)
-        ]
-        if diffs and all(abs(diff - diffs[0]) < 0.001 for diff in diffs):
-            self._attr_target_temperature_step = diffs[0]
-        else:
-            # The write method still validates against the exact five values.
-            self._attr_target_temperature_step = 0.5
-
     @property
     def hvac_mode(self) -> HVACMode:
-        # CD4 temperature regulation is constant supply-air control.
-        # Fan speed is intentionally handled by the separate fan entity.
+        # Temperature command 0 is Systemair Manual summer / panel "OFF".
+        # The ventilation fan may still be running; this only reports the
+        # state of the temperature-regulation part of this Climate entity.
+        temperature_level = self._get_int("temperature_level_command_register")
+        if temperature_level == 0:
+            return HVACMode.OFF
         return HVACMode.FAN_ONLY
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        if hvac_mode == HVACMode.OFF:
+            # Temperature regulation OFF / Manual summer mode.
+            # Deliberately do NOT touch the manual fan-speed register here.
+            await self._client.write_register(
+                self._model.ADDR_TEMPERATURE_LEVEL_COMMAND,
+                0,
+            )
+        elif hvac_mode == HVACMode.FAN_ONLY:
+            # Leaving Manual summer mode requires a valid 1..11 temperature
+            # command. Restore the last valid target known by this entity.
+            target = min(
+                max(float(self._last_target_temperature), self._attr_min_temp),
+                self._attr_max_temp,
+            )
+            level = int(round(target)) - 11
+            await self._client.write_register(
+                self._model.ADDR_TEMPERATURE_LEVEL_COMMAND,
+                level,
+            )
+        else:
+            return
+
+        await self.coordinator.async_request_refresh()
 
     @property
     def hvac_action(self) -> HVACAction:
-        """Report actual CD4 heating activity from the power-board relay."""
+        """Report the temperature-regulation activity of the CD4 climate."""
+        # REG_HC_TEMP_LVL = 0 means the temperature function itself is off,
+        # even though the ventilation fans can continue to run.
+        temperature_level = self._get_int("temperature_level_command_register")
+        if temperature_level == 0:
+            return HVACAction.OFF
+
         relays = self._get_int("pcu_pb_relays")
         if relays is not None and (relays & (1 << 1)):
             return HVACAction.HEATING
 
-        fan_level = self._get_int("manual_mode_command_register")
-        if fan_level == 0:
-            return HVACAction.OFF
-
+        # Temperature regulation is enabled, but no reheating is currently
+        # requested. Airflow may of course continue.
         return HVACAction.FAN
 
     @property
@@ -150,14 +167,30 @@ class SystemairCd4Climate(SystemairBaseEntity, ClimateEntity):
 
     @property
     def target_temperature(self) -> float | None:
-        self._update_temperature_limits()
+        level = self._get_int("temperature_level_command_register")
+        setpoint = self._get_float("temperature_setpoint")
 
-        active_level = self._get_int("temperature_setpoint_level")
-        if active_level is None or active_level == 0:
-            # Level 0 is Manual Summer mode and has no temperature target.
-            return None
+        # When temperature regulation is active, remember the valid target
+        # reported by the controller.
+        if (
+            level is not None
+            and 1 <= level <= 11
+            and setpoint is not None
+            and self._attr_min_temp <= setpoint <= self._attr_max_temp
+        ):
+            self._last_target_temperature = setpoint
+            return setpoint
 
-        return self._temperature_levels().get(active_level)
+        # REG_HC_TEMP_LVL = 0 is CD4 manual summer mode. The controller then
+        # reports REG_HC_TEMP_SP = 0, but returning None here makes Home
+        # Assistant hide the temperature control. Keep showing the last valid
+        # target instead, so selecting 12..22 °C can leave manual summer mode.
+        if level == 0:
+            return self._last_target_temperature
+
+        # During startup/temporary communication gaps, keep the last known
+        # target rather than removing the temperature control from the UI.
+        return self._last_target_temperature
 
     @property
     def fan_mode(self) -> str | None:
@@ -186,8 +219,6 @@ class SystemairCd4Climate(SystemairBaseEntity, ClimateEntity):
             return
 
         # Never translate an unsupported OFF request into another speed.
-        # If this CD4 unit does not support manual stop, "off" is not exposed
-        # in fan_modes and an unexpected external request is simply ignored.
         if level == 0 and not self._stop_allowed():
             return
 
@@ -207,20 +238,19 @@ class SystemairCd4Climate(SystemairBaseEntity, ClimateEntity):
         except (TypeError, ValueError):
             return
 
-        levels = self._temperature_levels()
-        if not levels:
+        # This working CD4 model supports 12..22 °C in exact 1 °C steps.
+        if requested < 12.0 or requested > 22.0:
             return
 
-        # Climate UI should already offer the correct step, but never send an
-        # unsupported value to the CD4 controller. Pick only an exact level.
-        selected_level = None
-        for level, temperature in levels.items():
-            if abs(requested - temperature) < 0.01:
-                selected_level = level
-                break
-
-        if selected_level is None:
+        rounded = round(requested)
+        if abs(requested - rounded) > 0.01:
             return
+
+        # 12 °C -> level 1
+        # 20 °C -> level 9
+        # 22 °C -> level 11
+        selected_level = int(rounded) - 11
+        self._last_target_temperature = float(rounded)
 
         await self._client.write_register(
             self._model.ADDR_TEMPERATURE_LEVEL_COMMAND,

--- a/custom_components/systemair_modbus/config_flow.py
+++ b/custom_components/systemair_modbus/config_flow.py
@@ -60,7 +60,7 @@ async def _async_validate_connection(
 
     client = ModbusTcpClient(host=host, port=port, slave=slave, gateway_profile=gateway_profile)
 
-    # Keep default at 10s, but allow more room for SAVE Connect safe mode
+    # Use a short validation timeout, but allow more room for SAVE Connect safe mode
     timeout_s = 10
     if gateway_profile == GATEWAY_PROFILE_SAVE_CONNECT:
         timeout_s = 25

--- a/custom_components/systemair_modbus/const.py
+++ b/custom_components/systemair_modbus/const.py
@@ -18,7 +18,7 @@ DEFAULT_GATEWAY_PROFILE = GATEWAY_PROFILE_GENERIC  # evt. bytt til SAVE_CONNECT 
 
 DEFAULT_PORT = 502
 DEFAULT_SLAVE = 1
-DEFAULT_SCAN_INTERVAL = 10  # seconds
+DEFAULT_SCAN_INTERVAL = 30  # seconds
 
 PLATFORMS: list[str] = ["sensor", "binary_sensor", "switch", "select", "number", "climate", "button"]
 

--- a/custom_components/systemair_modbus/manifest.json
+++ b/custom_components/systemair_modbus/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pymodbus>=3.11.2,<4.0.0"
   ],
-  "version": "1.3.0-beta.2"
+  "version": "1.3.0-beta.3"
 }

--- a/custom_components/systemair_modbus/models/cd4.py
+++ b/custom_components/systemair_modbus/models/cd4.py
@@ -1,8 +1,8 @@
 """Systemair CD4 / D24810 legacy model.
 
-The model exposes the documented CD4 fan controls, five-step supply-air
-temperature control and selected operating diagnostics while keeping the
-legacy register map conservative.
+The model exposes documented CD4 fan controls, supply-air temperature
+control and selected operating diagnostics while keeping the legacy
+register map conservative.
 
 Addresses below are Modbus client register offsets (0-based), i.e. Systemair
 documentation address minus 1.
@@ -45,13 +45,17 @@ class Cd4Model:
     MANUAL_SPEED_STOP_OPTION = "stop"
 
     # --- Supply-air temperature control (CD4) ---
-    # Systemair CD panel documentation describes five discrete supply-air
-    # temperature steps. Level 0 is manual summer mode.
+    # D24810 A007 documents REG_HC_TEMP_LVL as the R/W temperature
+    # set-point level (0 = manual summer mode, 1..5 legacy levels,
+    # 6..29 extended levels). Real VSR500/CD4 testing confirms that the
+    # user-facing range is 12..22 °C as levels 1..11.
     #
     # Register list:
     #   REG_HC_TEMP_LVL   PDF 207 -> Modbus offset 206, R/W command
-    #   REG_HC_TEMP_SP    PDF 208 -> Modbus offset 207, read active level
-    #   REG_HC_TEMP_LVL1..5 PDF 209..213 -> offsets 208..212, 0.1 °C
+    #   REG_HC_TEMP_SP    PDF 208 -> Modbus offset 207, actual setpoint * 10
+    #   REG_HC_TEMP_LVL1..5 PDF 209..213 -> offsets 208..212, legacy levels
+    #   REG_HC_TEMP_SP_DEG PDF 222 -> offset 221, regulation setpoint * 10
+    #   REG_HC_TEMP_SP_DEG_STEP PDF 236 -> offset 235, step size * 10
     ADDR_TEMPERATURE_LEVEL_COMMAND = r(206)
 
     # Raw registers enabled by default in Home Assistant.
@@ -61,7 +65,9 @@ class Cd4Model:
         "saf_speed_rpm",
         "eaf_speed_rpm",
 
-        # Phase 1 fan diagnostics
+        # Temperature-control registers are read for the Climate entity and
+        # remain available as disabled diagnostic sensors. They are not enabled
+        # by default because the Climate entity is the user-facing control.
 
         # Phase 1 temperature inputs.
         # Mapping is documented by Systemair:
@@ -203,10 +209,15 @@ class Cd4Model:
             data_type="uint16",
         ),
         RegisterDef(
-            key="temperature_setpoint_level",
+            key="temperature_setpoint",
             address=r(207),
             input_type="holding",
-            data_type="uint16",
+            data_type="int16",
+            scale=0.1,
+            precision=1,
+            unit="°C",
+            device_class="temperature",
+            state_class="measurement",
         ),
         RegisterDef(
             key="temperature_level_1",
@@ -255,6 +266,30 @@ class Cd4Model:
         RegisterDef(
             key="temperature_level_5",
             address=r(212),
+            input_type="holding",
+            data_type="int16",
+            scale=0.1,
+            precision=1,
+            unit="°C",
+            device_class="temperature",
+            state_class="measurement",
+        ),
+
+        # D24810 A007 extended temperature regulation diagnostics.
+        RegisterDef(
+            key="temperature_regulation_setpoint",
+            address=r(221),
+            input_type="holding",
+            data_type="int16",
+            scale=0.1,
+            precision=1,
+            unit="°C",
+            device_class="temperature",
+            state_class="measurement",
+        ),
+        RegisterDef(
+            key="temperature_setting_step",
+            address=r(235),
             input_type="holding",
             data_type="int16",
             scale=0.1,

--- a/custom_components/systemair_modbus/models/save.py
+++ b/custom_components/systemair_modbus/models/save.py
@@ -121,14 +121,31 @@ class SaveModel:
     MANUAL_SPEED_OPTIONS_INV: dict[int, str] = {v: k for k, v in MANUAL_SPEED_OPTIONS.items()}
 
     # Free cooling minimum fan speed uses the same discrete speed steps as manual speed.
-    FREE_COOLING_MIN_SPEED_OPTIONS: dict[str, int] = MANUAL_SPEED_OPTIONS
-    FREE_COOLING_MIN_SPEED_OPTIONS_INV: dict[int, str] = {v: k for k, v in FREE_COOLING_MIN_SPEED_OPTIONS.items()}
+    # Free cooling uses its own speed scale in the SAVE Modbus map:
+    # 3 = Normal, 4 = High, 5 = Maximum.
+    FREE_COOLING_MIN_SPEED_OPTIONS: dict[str, int] = {
+        "normal": 3,
+        "high": 4,
+        "maximum": 5,
+    }
+    FREE_COOLING_MIN_SPEED_OPTIONS_INV: dict[int, str] = {
+        v: k for k, v in FREE_COOLING_MIN_SPEED_OPTIONS.items()
+    }
 
     # Backwards-compatible aliases (older code used these names).
     MODE_COMMAND_OPTIONS = COMMAND_MODE_OPTIONS
     MODE_STATUS_TO_LABEL = STATUS_MODE_TO_LABEL
 
     REGISTERS: list[RegisterDef] = [
+        # --- Auto / demand-control diagnostics (issue #79) ---
+        # Systemair PDF IR 1003 / 1004 / 1007 / 1061 / 1062.
+        # Addresses below are PDF register number - 1.
+        RegisterDef(key='demand_supply_fan_speed', address=1002, input_type='input', data_type='uint16'),
+        RegisterDef(key='demand_active_controller', address=1003, input_type='input', data_type='uint16'),
+        RegisterDef(key='demand_extract_fan_speed', address=1006, input_type='input', data_type='uint16'),
+        RegisterDef(key='demand_control_enabled', address=1060, input_type='input', data_type='uint16'),
+        RegisterDef(key='auto_mode_source', address=1061, input_type='input', data_type='uint16'),
+
         # --- Modes and time settings ---
         RegisterDef(key='summer_winter_operation_1_0', address=1038, input_type='input', data_type='uint16'),
         RegisterDef(key='holiday_mode_duration', address=1100, input_type='holding', data_type='uint16', unit='days'),
@@ -189,7 +206,9 @@ class SaveModel:
         RegisterDef(key='supply_air_room_exhaust_reg', address=2030, input_type='holding', data_type='uint16'),
 
         # --- Heating and humidity ---
+        RegisterDef(key='heater_from_satc', address=2113, input_type='input', data_type='uint16', unit='%'),
         RegisterDef(key='triac_after_manual_override', address=2148, input_type='input', data_type='uint16', unit='%'),
+        RegisterDef(key='heating_active', address=3102, input_type='input', data_type='uint16'),
         RegisterDef(key='moisture_extraction_sp', address=2202, input_type='holding', data_type='uint16', unit='%', device_class='humidity'),
         RegisterDef(key='calculated_moisture_extraction', address=2210, input_type='holding', data_type='uint16', unit='%', device_class='humidity'),
         RegisterDef(key='calculated_moisture_intake', address=2211, input_type='holding', data_type='uint16', unit='%', device_class='humidity'),
@@ -198,6 +217,7 @@ class SaveModel:
         RegisterDef(key='eco_heat_offset', address=2503, input_type='holding', data_type='uint16', scale=0.1, precision=1, unit='°C', device_class='temperature'),
         RegisterDef(key='eco_mode', address=2504, input_type='holding', data_type='uint16'),
         RegisterDef(key='eco_function_active', address=2505, input_type='input', data_type='uint16'),
+        RegisterDef(key='eco_mode_active', address=2520, input_type='input', data_type='uint16'),
 
         # --- Free Cooling ---
         RegisterDef(key='free_cooling_enable', address=4100, input_type='holding', data_type='uint16'),
@@ -209,9 +229,13 @@ class SaveModel:
         RegisterDef(key='free_cooling_start_time_m', address=4106, input_type='holding', data_type='uint16'),
         RegisterDef(key='free_cooling_end_time_h', address=4107, input_type='holding', data_type='uint16'),
         RegisterDef(key='free_cooling_end_time_m', address=4108, input_type='holding', data_type='uint16'),
+        RegisterDef(key='free_cooling_function_active', address=3101, input_type='input', data_type='uint16'),
         RegisterDef(key='free_cooling_active', address=4110, input_type='input', data_type='uint16'),
         RegisterDef(key='free_cooling_min_speed_saf', address=4111, input_type='holding', data_type='uint16'),
         RegisterDef(key='free_cooling_min_speed_eaf', address=4112, input_type='holding', data_type='uint16'),
+        RegisterDef(key='free_cooling_state', address=4113, input_type='input', data_type='uint16'),
+        RegisterDef(key='free_cooling_heater_block_counter', address=4118, input_type='input', data_type='uint16', unit='s'),
+        RegisterDef(key='free_cooling_reliable_temperatures', address=4119, input_type='input', data_type='uint16'),
 
         # --- Filter ---
         RegisterDef(key='filter_replacement_period', address=7000, input_type='holding', data_type='uint16', unit='months'),
@@ -234,6 +258,7 @@ class SaveModel:
         # --- Outputs and alarms ---
         RegisterDef(key='supply_air_fan_pwr_fact', address=14000, input_type='input', data_type='uint16', unit='%'),
         RegisterDef(key='extractor_fan_pwr_fact', address=14001, input_type='input', data_type='uint16', unit='%'),
+        RegisterDef(key='heater_y1_analog_output', address=14100, input_type='input', data_type='uint16', unit='%'),
         RegisterDef(key='heat_recovery', address=14102, input_type='input', data_type='uint16', unit='%'),
         RegisterDef(key='triac_control_signal', address=14380, input_type='input', data_type='uint16'),
         RegisterDef(key='filter_alarm', address=15141, input_type='input', data_type='uint16'),
@@ -347,7 +372,7 @@ class SaveModel:
         man = _to_int(data.get("manual_mode_command_register"), -1)
 
         if mode == 0:
-            out["mode_status_text"] = "auto_demand_control"
+            out["mode_status_text"] = "auto"
         elif mode == 1:
             out["mode_status_text"] = {
                 0: "manual_stop",

--- a/custom_components/systemair_modbus/sensor.py
+++ b/custom_components/systemair_modbus/sensor.py
@@ -57,6 +57,10 @@ def _pretty_reg_name(key: str) -> str:
 
         # Free cooling (night cooling)
         "free_cooling_active": "Free cooling active",
+        "free_cooling_function_active": "Free cooling function active",
+        "free_cooling_state": "Free cooling state",
+        "free_cooling_heater_block_counter": "Free cooling heater block counter",
+        "free_cooling_reliable_temperatures": "Free cooling reliable temperatures",
         "free_cooling_daytime_min_temp": "Free cooling – daytime min temp",
         "free_cooling_night_high_limit": "Free cooling – night high limit",
         "free_cooling_night_low_limit": "Free cooling – night low limit",
@@ -154,6 +158,11 @@ ENABLED_RAW_KEYS: set[str] = {
     "relative_moisture_extraction",
     # Heat recovery
     "heat_recovery",
+    # SAVE issue #76 - user-facing reheater output
+    "triac_after_manual_override",
+    # SAVE issue #78:
+    # The internal state/counter registers are available as diagnostics,
+    # but are intentionally disabled by default after real-unit testing.
 }
 
 
@@ -170,6 +179,15 @@ CD4_TRANSLATED_SENSOR_KEYS: set[str] = {
     "saf_pwm",
     "eaf_pwm",
     "fan_speed_level_cd",
+    "temperature_level_command_register",
+    "temperature_setpoint",
+    "temperature_level_1",
+    "temperature_level_2",
+    "temperature_level_3",
+    "temperature_level_4",
+    "temperature_level_5",
+    "temperature_regulation_setpoint",
+    "temperature_setting_step",
     "temperature_sensor_1",
     "temperature_sensor_2",
     "temperature_sensor_3",
@@ -194,16 +212,9 @@ CD4_BINARY_SENSOR_SOURCE_KEYS: set[str] = {
     "alarm_relay_active",
 }
 
-# CD4 temperature-control registers are read by the coordinator for the
-# temperature control entity, but are not useful as separate raw sensors.
+# Registers represented by dedicated higher-level entities and therefore not
+# exposed as duplicate numeric sensors.
 CD4_INTERNAL_SENSOR_KEYS: set[str] = {
-    "temperature_level_command_register",
-    "temperature_setpoint_level",
-    "temperature_level_1",
-    "temperature_level_2",
-    "temperature_level_3",
-    "temperature_level_4",
-    "temperature_level_5",
     "pcu_pb_relays",
 }
 
@@ -221,6 +232,44 @@ CD4_ENUM_VALUE_MAPS: dict[str, dict[int, str]] = {
         1: "reduced_flow",
         2: "bypass",
         3: "stop",
+    },
+}
+
+
+SAVE_BINARY_SENSOR_SOURCE_KEYS: set[str] = {
+    "heating_active",
+    "eco_mode_active",
+    "eco_function_active",
+    "free_cooling_active",
+    "free_cooling_function_active",
+    "free_cooling_reliable_temperatures",
+    "demand_control_enabled",
+}
+
+# SAVE diagnostics that should use translations even when disabled by default.
+SAVE_TRANSLATED_SENSOR_KEYS: set[str] = {
+    "auto_mode_source",
+    "demand_active_controller",
+    "demand_supply_fan_speed",
+    "demand_extract_fan_speed",
+}
+
+SAVE_ENUM_VALUE_MAPS: dict[str, dict[int, str]] = {
+    "free_cooling_state": {
+        0: "disabled",
+        1: "enabled",
+        2: "daytime",
+        3: "temperatures_not_reliable",
+    },
+    "auto_mode_source": {
+        0: "external_control",
+        1: "demand_control",
+        2: "week_schedule",
+        3: "configuration_fault",
+    },
+    "demand_active_controller": {
+        0: "co2",
+        1: "rh",
     },
 }
 
@@ -255,6 +304,8 @@ async def async_setup_entry(
         if is_cd4 and _base_key(reg.key) in CD4_BINARY_SENSOR_SOURCE_KEYS:
             continue
         if is_cd4 and _base_key(reg.key) in CD4_INTERNAL_SENSOR_KEYS:
+            continue
+        if not is_cd4 and _base_key(reg.key) in SAVE_BINARY_SENSOR_SOURCE_KEYS:
             continue
 
         entities.append(SystemairRegisterSensor(coordinator, entry, reg))
@@ -298,6 +349,8 @@ class SystemairRegisterSensor(SystemairBaseEntity, SensorEntity):
         translated_keys = set(ENABLED_RAW_KEYS)
         if self._is_cd4:
             translated_keys |= CD4_TRANSLATED_SENSOR_KEYS
+        else:
+            translated_keys |= SAVE_TRANSLATED_SENSOR_KEYS
 
         if self._base_key in translated_keys:
             self._attr_translation_key = self._base_key
@@ -321,7 +374,10 @@ class SystemairRegisterSensor(SystemairBaseEntity, SensorEntity):
         if reg.state_class:
             self._attr_state_class = reg.state_class
 
-        enum_map = CD4_ENUM_VALUE_MAPS.get(self._base_key) if self._is_cd4 else None
+        if self._is_cd4:
+            enum_map = CD4_ENUM_VALUE_MAPS.get(self._base_key)
+        else:
+            enum_map = SAVE_ENUM_VALUE_MAPS.get(self._base_key)
         if enum_map is not None:
             self._enum_map = enum_map
             self._attr_device_class = SensorDeviceClass.ENUM

--- a/custom_components/systemair_modbus/strings.json
+++ b/custom_components/systemair_modbus/strings.json
@@ -42,6 +42,22 @@
           "normal": "Normal",
           "high": "High"
         }
+      },
+      "free_cooling_min_saf": {
+        "name": "Free cooling – minimum supply fan speed",
+        "state": {
+          "normal": "Normal",
+          "high": "High",
+          "maximum": "Maximum"
+        }
+      },
+      "free_cooling_min_eaf": {
+        "name": "Free cooling – minimum extract fan speed",
+        "state": {
+          "normal": "Normal",
+          "high": "High",
+          "maximum": "Maximum"
+        }
       }
     },
     "fan": {
@@ -71,6 +87,9 @@
       }
     },
     "binary_sensor": {
+      "heating_active": {
+        "name": "Reheater active"
+      },
       "cd4_preheater_active": {
         "name": "Preheater active"
       },
@@ -79,6 +98,84 @@
       },
       "cd4_heater_relay_active": {
         "name": "Heater relay active"
+      },
+      "eco_mode_active": {
+        "name": "Eco active"
+      },
+      "free_cooling_function_active": {
+        "name": "Free cooling function active"
+      },
+      "free_cooling_reliable_temperatures": {
+        "name": "Free cooling temperatures reliable"
+      },
+      "demand_control_enabled": {
+        "name": "Demand control enabled"
+      }
+    },
+    "sensor": {
+      "free_cooling_heater_block_counter": {
+        "name": "Heating blocked after free cooling"
+      },
+      "free_cooling_state": {
+        "name": "Free cooling state",
+        "state": {
+          "disabled": "Disabled",
+          "enabled": "Enabled",
+          "daytime": "Daytime",
+          "temperatures_not_reliable": "Temperatures not reliable",
+          "unknown": "Unknown"
+        }
+      },
+      "auto_mode_source": {
+        "name": "Auto mode source",
+        "state": {
+          "external_control": "External control",
+          "demand_control": "Demand control",
+          "week_schedule": "Week schedule",
+          "configuration_fault": "Configuration fault",
+          "unknown": "Unknown"
+        }
+      },
+      "demand_active_controller": {
+        "name": "Demand control – reported controller",
+        "state": {
+          "co2": "CO₂",
+          "rh": "RH",
+          "unknown": "Unknown"
+        }
+      },
+      "demand_supply_fan_speed": {
+        "name": "Demand control – supply fan speed"
+      },
+      "demand_extract_fan_speed": {
+        "name": "Demand control – extract fan speed"
+      },
+      "temperature_level_command_register": {
+        "name": "Temperature level command"
+      },
+      "temperature_setpoint": {
+        "name": "Temperature setpoint"
+      },
+      "temperature_level_1": {
+        "name": "Legacy temperature level 1"
+      },
+      "temperature_level_2": {
+        "name": "Legacy temperature level 2"
+      },
+      "temperature_level_3": {
+        "name": "Legacy temperature level 3"
+      },
+      "temperature_level_4": {
+        "name": "Legacy temperature level 4"
+      },
+      "temperature_level_5": {
+        "name": "Legacy temperature level 5"
+      },
+      "temperature_regulation_setpoint": {
+        "name": "Temperature regulation setpoint"
+      },
+      "temperature_setting_step": {
+        "name": "Temperature setting step"
       }
     }
   }

--- a/custom_components/systemair_modbus/translations/en.json
+++ b/custom_components/systemair_modbus/translations/en.json
@@ -174,6 +174,79 @@
       },
       "filter_days": {
         "name": "Days since filter replacement"
+      },
+      "heater_from_satc": {
+        "name": "Reheater heating demand"
+      },
+      "triac_after_manual_override": {
+        "name": "Reheater output"
+      },
+      "heater_y1_analog_output": {
+        "name": "Reheater Y1 output"
+      },
+      "free_cooling_heater_block_counter": {
+        "name": "Heating blocked after free cooling"
+      },
+      "free_cooling_state": {
+        "name": "Free cooling state",
+        "state": {
+          "disabled": "Disabled",
+          "enabled": "Enabled",
+          "daytime": "Daytime",
+          "temperatures_not_reliable": "Temperatures not reliable",
+          "unknown": "Unknown"
+        }
+      },
+      "auto_mode_source": {
+        "name": "Auto mode source",
+        "state": {
+          "external_control": "External control",
+          "demand_control": "Demand control",
+          "week_schedule": "Week schedule",
+          "configuration_fault": "Configuration fault",
+          "unknown": "Unknown"
+        }
+      },
+      "demand_active_controller": {
+        "name": "Demand control – reported controller",
+        "state": {
+          "co2": "CO₂",
+          "rh": "RH",
+          "unknown": "Unknown"
+        }
+      },
+      "demand_supply_fan_speed": {
+        "name": "Demand control – supply fan speed"
+      },
+      "demand_extract_fan_speed": {
+        "name": "Demand control – extract fan speed"
+      },
+      "temperature_level_command_register": {
+        "name": "Temperature level command"
+      },
+      "temperature_setpoint": {
+        "name": "Temperature setpoint"
+      },
+      "temperature_level_1": {
+        "name": "Legacy temperature level 1"
+      },
+      "temperature_level_2": {
+        "name": "Legacy temperature level 2"
+      },
+      "temperature_level_3": {
+        "name": "Legacy temperature level 3"
+      },
+      "temperature_level_4": {
+        "name": "Legacy temperature level 4"
+      },
+      "temperature_level_5": {
+        "name": "Legacy temperature level 5"
+      },
+      "temperature_regulation_setpoint": {
+        "name": "Temperature regulation setpoint"
+      },
+      "temperature_setting_step": {
+        "name": "Temperature setting step"
       }
     },
     "switch": {
@@ -198,10 +271,20 @@
         }
       },
       "free_cooling_min_saf": {
-        "name": "Free cooling – min supply"
+        "name": "Free cooling – minimum supply fan speed",
+        "state": {
+          "normal": "Normal",
+          "high": "High",
+          "maximum": "Maximum"
+        }
       },
       "free_cooling_min_eaf": {
-        "name": "Free cooling – min extract"
+        "name": "Free cooling – minimum extract fan speed",
+        "state": {
+          "normal": "Normal",
+          "high": "High",
+          "maximum": "Maximum"
+        }
       },
       "manual_speed_command": {
         "name": "Manual speed"
@@ -315,6 +398,9 @@
       "pressure_guard_active": {
         "name": "Pressure guard active"
       },
+      "heating_active": {
+        "name": "Reheater active"
+      },
       "cd4_rotor_active": {
         "name": "Rotor active"
       },
@@ -332,6 +418,18 @@
       },
       "cd4_heater_relay_active": {
         "name": "Heater relay active"
+      },
+      "eco_mode_active": {
+        "name": "Eco active"
+      },
+      "free_cooling_function_active": {
+        "name": "Free cooling function active"
+      },
+      "free_cooling_reliable_temperatures": {
+        "name": "Free cooling temperatures reliable"
+      },
+      "demand_control_enabled": {
+        "name": "Demand control enabled"
       }
     },
     "climate": {

--- a/custom_components/systemair_modbus/translations/nb.json
+++ b/custom_components/systemair_modbus/translations/nb.json
@@ -174,6 +174,79 @@
       },
       "filter_days": {
         "name": "Dager siden filterskift"
+      },
+      "heater_from_satc": {
+        "name": "Ettervarme varmebehov"
+      },
+      "triac_after_manual_override": {
+        "name": "Ettervarme effekt"
+      },
+      "heater_y1_analog_output": {
+        "name": "Ettervarme Y1-utgang"
+      },
+      "free_cooling_heater_block_counter": {
+        "name": "Ettervarme blokkert etter frikjøling"
+      },
+      "free_cooling_state": {
+        "name": "Frikjøling status",
+        "state": {
+          "disabled": "Deaktivert",
+          "enabled": "Aktivert",
+          "daytime": "Dagmodus",
+          "temperatures_not_reliable": "Temperaturer ikke pålitelige",
+          "unknown": "Ukjent"
+        }
+      },
+      "auto_mode_source": {
+        "name": "Auto – styrekilde",
+        "state": {
+          "external_control": "Ekstern styring",
+          "demand_control": "Behovsstyring",
+          "week_schedule": "Ukeprogram",
+          "configuration_fault": "Konfigurasjonsfeil",
+          "unknown": "Ukjent"
+        }
+      },
+      "demand_active_controller": {
+        "name": "Behovsstyring – rapportert regulator",
+        "state": {
+          "co2": "CO₂",
+          "rh": "RH",
+          "unknown": "Ukjent"
+        }
+      },
+      "demand_supply_fan_speed": {
+        "name": "Behovsstyring – tilluftsvifte"
+      },
+      "demand_extract_fan_speed": {
+        "name": "Behovsstyring – avtrekksvifte"
+      },
+      "temperature_level_command_register": {
+        "name": "Temperaturnivå – råverdi"
+      },
+      "temperature_setpoint": {
+        "name": "Temperatursettpunkt"
+      },
+      "temperature_level_1": {
+        "name": "Legacy temperaturnivå 1"
+      },
+      "temperature_level_2": {
+        "name": "Legacy temperaturnivå 2"
+      },
+      "temperature_level_3": {
+        "name": "Legacy temperaturnivå 3"
+      },
+      "temperature_level_4": {
+        "name": "Legacy temperaturnivå 4"
+      },
+      "temperature_level_5": {
+        "name": "Legacy temperaturnivå 5"
+      },
+      "temperature_regulation_setpoint": {
+        "name": "Temperaturregulering – settpunkt"
+      },
+      "temperature_setting_step": {
+        "name": "Temperaturregulering – trinnstørrelse"
       }
     },
     "switch": {
@@ -198,10 +271,20 @@
         }
       },
       "free_cooling_min_saf": {
-        "name": "Frikjøling – min. tilluft"
+        "name": "Frikjøling – min. tilluftshastighet",
+        "state": {
+          "normal": "Normal",
+          "high": "Høy",
+          "maximum": "Maksimum"
+        }
       },
       "free_cooling_min_eaf": {
-        "name": "Frikjøling – min. avtrekk"
+        "name": "Frikjøling – min. avtrekkshastighet",
+        "state": {
+          "normal": "Normal",
+          "high": "Høy",
+          "maximum": "Maksimum"
+        }
       },
       "manual_speed_command": {
         "name": "Manuell hastighet"
@@ -224,7 +307,7 @@
         "name": "Trengsel varighet (timer)"
       },
       "eco_heat_offset": {
-        "name": "Øko varmeoffset"
+        "name": "Eco varmeoffset"
       },
       "free_cooling_outdoor_min": {
         "name": "Frikjøling ute min (°C)"
@@ -310,10 +393,13 @@
         "name": "Kjøkkenhette aktiv"
       },
       "eco_function_active": {
-        "name": "Øko-funksjon aktiv"
+        "name": "Eco-funksjon aktiv"
       },
       "pressure_guard_active": {
         "name": "Trykkvakt aktiv"
+      },
+      "heating_active": {
+        "name": "Ettervarme aktiv"
       },
       "cd4_rotor_active": {
         "name": "Rotor aktiv"
@@ -332,6 +418,18 @@
       },
       "cd4_heater_relay_active": {
         "name": "Varmerelé aktiv"
+      },
+      "eco_mode_active": {
+        "name": "Eco aktiv"
+      },
+      "free_cooling_function_active": {
+        "name": "Frikjøling funksjon aktiv"
+      },
+      "free_cooling_reliable_temperatures": {
+        "name": "Frikjøling temperaturer pålitelige"
+      },
+      "demand_control_enabled": {
+        "name": "Behovsstyring aktivert"
       }
     },
     "climate": {


### PR DESCRIPTION
Implements SAVE improvements based on #76, #77, #78, #79 and #87.
Includes CD4 work building on #73 and #74.

Thanks to @stboee for extensive SAVE register research, feature proposals and testing across #76–#79.

Thanks to @gljo for hardware testing and verification of the CD4 OFF / 12–22 °C temperature mapping.

Thanks to @Ztaeyn for reporting and helping investigate the touch-display stability issue in #87.